### PR TITLE
feat: Add CV icon with placeholder link

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,15 @@
 </a>
 <a href="mailto:cg3danim@gmail.com" class="styled-email-link mobile-email-link">cg3danim@gmail.com</a>
 <button id="darkModeToggleMobile" class="dark-mode-btn">Toggle Dark Mode</button>
+<a href="#" target="_blank" class="cv-icon-link" aria-label="Download CV">
+  <svg class="cv-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+    <polyline points="14 2 14 8 20 8"></polyline>
+    <line x1="16" y1="13" x2="8" y2="13"></line>
+    <line x1="16" y1="17" x2="8" y2="17"></line>
+    <polyline points="10 9 9 9 8 9"></polyline>
+  </svg>
+</a>
 <div class="mobile-footer">
   © All Rights Reserved. Carlos Gomez.
 </div>
@@ -60,6 +69,15 @@
 </nav>
       </div>
       <button id="darkModeToggle">Toggle Dark Mode</button>
+      <a href="#" target="_blank" class="cv-icon-link" aria-label="Download CV">
+        <svg class="cv-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+          <polyline points="14 2 14 8 20 8"></polyline>
+          <line x1="16" y1="13" x2="8" y2="13"></line>
+          <line x1="16" y1="17" x2="8" y2="17"></line>
+          <polyline points="10 9 9 9 8 9"></polyline>
+        </svg>
+      </a>
 <footer class="site-footer">
   <p>© All Rights Reserved. Carlos Gomez.</p>
 </footer>

--- a/styles.css
+++ b/styles.css
@@ -749,3 +749,24 @@ body.dark-mode .styled-email-link:hover {
     border: none; /* Remove default iframe border */
 }
 
+.cv-icon-link {
+  display: block;
+  text-align: center;
+  margin-top: 1rem;
+  color: #555;
+}
+
+.cv-icon {
+  width: 24px;
+  height: 24px;
+  stroke: currentColor;
+  transition: transform 0.2s ease;
+}
+
+.cv-icon-link:hover .cv-icon {
+  transform: scale(1.1);
+}
+
+body.dark-mode .cv-icon-link {
+  color: #bbb;
+}


### PR DESCRIPTION
Adds a CV icon with a placeholder link below the dark mode toggle button for both mobile and desktop views. The user has been instructed to update the placeholder link with the actual path to their CV.